### PR TITLE
added a single comma for tuple-making

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,7 +245,7 @@ def removeBook():
     bookID = req.args.get("bookRem")
     print(bookID)
     c.execute("DELETE FROM UserBooks WHERE id = ?",
-              (bookID))
+              (bookID,))
     db.commit()
     db.close()
 


### PR DESCRIPTION
A single MF comma was missing to make a viable single-entry tuple.  Python: C'mon, man!